### PR TITLE
#7 suffix content_settings.VAR_NAME__attr

### DIFF
--- a/content_settings/admin.py
+++ b/content_settings/admin.py
@@ -292,13 +292,6 @@ class ContentSettingAdmin(admin.ModelAdmin):
             )
 
         urls = [get_fetch_reverse(obj.name)]
-        fetch_groups = ALL[obj.name].fetch_groups
-        if fetch_groups is not None:
-            if isinstance(fetch_groups, str):
-                fetch_groups = [fetch_groups]
-
-            urls += [get_fetch_reverse(n) for n in fetch_groups]
-
         return "\n".join(urls)
 
     def get_urls(self):

--- a/content_settings/caching.py
+++ b/content_settings/caching.py
@@ -77,12 +77,12 @@ def set_new_value(name, new_value, version=None):
     return prev_value
 
 
-def get_value(name):
+def get_value(name, suffix=None):
     assert DATA.POPULATED
 
     from .conf import ALL
 
-    return ALL[name].give(DATA.ALL_VALUES[name])
+    return ALL[name].give(DATA.ALL_VALUES[name], suffix)
 
 
 def is_populated():  # better name?

--- a/content_settings/types/array.py
+++ b/content_settings/types/array.py
@@ -107,5 +107,5 @@ class TypedStringsList(SimpleStringsList):
         yield "Each line is "
         yield from self.line_type.get_help_format()
 
-    def give(self, value):
+    def give(self, value, suffix=None):
         return [self.line_type.give(v) for v in value]

--- a/content_settings/types/basic.py
+++ b/content_settings/types/basic.py
@@ -153,7 +153,7 @@ class SimpleString(BaseSetting):
         return value
 
     def give_python_to_admin(self, value, name):
-        return self.give_python(value)
+        return self.to_python(value)
 
     def get_admin_preview_html(self, value, name):
         return self.give_python_to_admin(value, name)

--- a/content_settings/types/basic.py
+++ b/content_settings/types/basic.py
@@ -6,6 +6,7 @@ from django import forms
 
 from content_settings.context_managers import context_defaults_kwargs
 from content_settings.settings import CACHE_SPLITER
+from content_settings.types.lazy import LazyObject
 from content_settings.types import (
     PREVIEW_ALL,
     PREVIEW_HTML,
@@ -29,10 +30,10 @@ class SimpleString(BaseSetting):
     value_required = False
     version = ""
     tags = None
-    fetch_groups = None
     validators = ()
     empty_is_none = False
     admin_preview_as = PREVIEW_TEXT
+    suffixes = ()
 
     def __init__(self, default="", **kwargs):
         for k in kwargs.keys():
@@ -74,6 +75,12 @@ class SimpleString(BaseSetting):
     @cached_property
     def field(self):
         return self.get_field()
+
+    def get_suffixes(self):
+        return self.suffixes
+
+    def can_suffix(self, suffix):
+        return suffix is None or suffix in self.get_suffixes()
 
     def can_assign(self, name):
         return hasattr(self, name)
@@ -173,11 +180,14 @@ class SimpleString(BaseSetting):
             .replace('"', "&quot;")
         )
 
-    def give(self, value):
+    def lazy_give(self, l_func, suffix=None):
+        return LazyObject(l_func)
+
+    def give(self, value, suffix=None):
         return value
 
-    def give_python(self, value):
-        return self.give(self.to_python(value))
+    def give_python(self, value, suffix=None):
+        return self.give(self.to_python(value), suffix)
 
 
 class SimpleText(SimpleString):

--- a/content_settings/types/lazy.py
+++ b/content_settings/types/lazy.py
@@ -1,0 +1,41 @@
+import operator
+
+
+class LazyObject:
+    def __init__(self, factory):
+        # Assign using __dict__ to avoid the setattr method.
+        self.__dict__["_factory"] = factory
+
+    def new_method_proxy(func):
+        """
+        Util function to help us route functions
+        to the nested object.
+        """
+
+        def inner(self, *args):
+            return func(self._factory(), *args)
+
+        return inner
+
+    def __call__(self, *args, **kwargs):
+        return self._factory()(*args, **kwargs)
+
+    __getattr__ = new_method_proxy(getattr)
+    __bytes__ = new_method_proxy(bytes)
+    __str__ = new_method_proxy(str)
+    __bool__ = new_method_proxy(bool)
+    __dir__ = new_method_proxy(dir)
+    __hash__ = new_method_proxy(hash)
+    __class__ = property(new_method_proxy(operator.attrgetter("__class__")))
+    __eq__ = new_method_proxy(operator.eq)
+    __lt__ = new_method_proxy(operator.lt)
+    __le__ = new_method_proxy(operator.le)
+    __gt__ = new_method_proxy(operator.gt)
+    __ge__ = new_method_proxy(operator.ge)
+    __ne__ = new_method_proxy(operator.ne)
+    __mod__ = new_method_proxy(operator.mod)
+    __hash__ = new_method_proxy(hash)
+    __getitem__ = new_method_proxy(operator.getitem)
+    __iter__ = new_method_proxy(iter)
+    __len__ = new_method_proxy(len)
+    __contains__ = new_method_proxy(operator.contains)

--- a/content_settings/types/markup.py
+++ b/content_settings/types/markup.py
@@ -110,7 +110,7 @@ class SimpleCSV(SimpleText):
             return None
         return list(val)
 
-    def give(self, value):
+    def give(self, value, suffix=None):
         if not value:
             return value
         return [

--- a/content_settings/types/mixins.py
+++ b/content_settings/types/mixins.py
@@ -165,7 +165,7 @@ class MakeCallMixin:
         return self.give_python(value)()
 
     def give(self, value, suffix=None):
-        return lambda: value
+        return lambda *args, **kwargs: value
 
 
 class DictSuffixesMixin:

--- a/content_settings/types/mixins.py
+++ b/content_settings/types/mixins.py
@@ -70,7 +70,7 @@ class CallToPythonMixin:
 
     def give_python_to_admin(self, value, name):
         try:
-            value = self.give_python(value)
+            value = self.to_python(value)
         except Exception as e:
             return [(None, e)]
         ret = []
@@ -143,17 +143,21 @@ class GiveCallMixin:
 
     admin_preview_call = False
 
-    def give_python_to_admin(self, value, name):
-        value = self.give_python(value)
-        return [
-            (None, value),
-        ]
+    def get_suffixes(self):
+        return ("call",) + super().get_suffixes()
 
     def get_validators(self):
-        return (call_validator(),)
+        return (call_validator(),) + super().get_validators()
+
+    def get_preview_validators(self):
+        return (call_validator(),) + super().get_preview_validators()
 
     def give(self, value, suffix=None):
-        return value()
+        if suffix is None:
+            return value()
+        if suffix == "call":
+            return value
+        return super().give(value, suffix)
 
 
 class MakeCallMixin:

--- a/content_settings/types/mixins.py
+++ b/content_settings/types/mixins.py
@@ -152,7 +152,7 @@ class GiveCallMixin:
     def get_validators(self):
         return (call_validator(),)
 
-    def give(self, value):
+    def give(self, value, suffix=None):
         return value()
 
 
@@ -160,5 +160,14 @@ class MakeCallMixin:
     def give_python_to_admin(self, value, name):
         return self.give_python(value)()
 
-    def give(self, value):
+    def give(self, value, suffix=None):
         return lambda: value
+
+
+class DictSuffixesMixin:
+    suffixes = {}
+
+    def give(self, value, suffix=None):
+        if suffix is None:
+            return value
+        return self.suffixes[suffix](value)

--- a/content_settings/types/template.py
+++ b/content_settings/types/template.py
@@ -138,15 +138,6 @@ class DjangoModelTemplate(DjangoTemplate):
 
         return validators
 
-    def get_validators(self):
-        validators = super().get_validators()
-        first_validator = self.get_first_call_validator()
-
-        if first_validator is not None:
-            validators = (first_validator, *validators)
-
-        return validators
-
     def get_preview_validators(self):
         first_validator = self.get_first_call_validator()
 

--- a/content_settings/urls.py
+++ b/content_settings/urls.py
@@ -5,4 +5,9 @@ from .views import fetch_one_setting
 app_name = "content_settings"
 urlpatterns = [
     path("fetch/<str:name>/", fetch_one_setting, name="fetch_one_setting"),
+    path(
+        "fetch/<str:name>/suffix/<str:suffix>/",
+        fetch_one_setting,
+        name="fetch_one_setting",
+    ),
 ]

--- a/docs/access.md
+++ b/docs/access.md
@@ -109,22 +109,25 @@ The result will be in JSON format:
 
 ### Fetching Multiple Variables
 
-Use the `fetch_groups` attribute to return multiple variables in a single request:
+Use the `content_settings.views.FetchSettingsView` view for fetching multiple attributes:
 
 ```python
-from content_settings.types.basic import SimpleString, SimpleText
-from content_settings import permissions
+from django.urls import path
+from content_settings.views import FetchSettingsView
 
-DESCRIPTION = SimpleText(
-    "The best book store in the world",
-    fetch_groups="home-detail",
-    fetch_permission=permissions.any,
-)
-TITLE = SimpleString(
-    "Book Store",
-    fetch_groups="home-detail",
-    fetch_permission=permissions.any,
-)
+
+urlpatterns = [
+    path("fetch/main/", FetchSettingsView.as_view(attrs=[
+        "TITLE",
+        "BOOKS__available_names",
+    ]), name="fetch_main"),
+    path("fetch/home-detail/", FetchSettingsView.as_view(attrs=[
+        "DESCRIPTION",
+        "OPEN_DATE",
+        "TITLE",
+    ]), name="fetch_home_detail"),
+]
+
 ```
 
 Fetching the group `home-detail` via API:

--- a/docs/types.md
+++ b/docs/types.md
@@ -145,6 +145,8 @@ content_settings.TITLE_IMG
 # /static/title.png
 ```
 
+    - you can still pass input arguments `call` suffix, like `content_settings.TITLE_IMG__call`
+
 - **DjangoModelTemplate**: is a specialized class for rendering templates for individual Django model objects
     - **model_queryset**: A query set of objects that can be used as an argument. The setting only takes the first element for preview purposes in the admin panel.
     - **obj_name**: The name under which the model object is passed to the template.

--- a/docs/types.md
+++ b/docs/types.md
@@ -38,7 +38,6 @@ You can learn more about fields and widgets in [official Django Forms documentat
 Note: Validators are not used when converting text from the database to the variable object.
 
 - **update_permission** and **fetch_permission**: Access rights for changing the variable in the admin panel (detailed in a separate article).
-- **fetch_groups**: Grouping multiple variables in one API request (detailed in the API section).
 - **admin_preview_as** (default: PREVIEW_TEXT): when you change values in Django Admin text field you see preview of the converted object. This attribute shows how the preview will look like. It has the followig options and all of them can be found in constants `content_settings.PREVIEW_*`:
     - `PREVIEW_TEXT` - the value will be shown as plain text inside of pre html element
     - `PREVIEW_HTML` - the value will be shown as it is without esceping

--- a/tests/books/urls.py
+++ b/tests/books/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from django.views.generic import TemplateView, ListView
 
 from .models import Book
+from content_settings.views import FetchSettingsView
 
 
 class BookListView(ListView):
@@ -13,4 +14,34 @@ app_name = "books"
 urlpatterns = [
     path("", TemplateView.as_view(template_name="books/index.html"), name="index"),
     path("list/", BookListView.as_view(), name="list"),
+    path(
+        "fetch/main/",
+        FetchSettingsView.as_view(
+            attrs=[
+                "TITLE",
+                "BOOKS__available_names",
+            ]
+        ),
+        name="fetch_main",
+    ),
+    path(
+        "fetch/home-detail/",
+        FetchSettingsView.as_view(
+            attrs=[
+                "DESCRIPTION",
+                "OPEN_DATE",
+                "TITLE",
+            ]
+        ),
+        name="fetch_home_detail",
+    ),
+    path(
+        "fetch/home/",
+        FetchSettingsView.as_view(
+            attrs=[
+                "TITLE",
+            ]
+        ),
+        name="fetch_home_detail",
+    ),
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,14 +52,14 @@ def test_get_simple_text():
 
 def test_fetch_group_signle_value():
     client = get_anonymous_client()
-    resp = client.get("/content-settings/fetch/home/")
+    resp = client.get("/books/fetch/home/")
     assert resp.status_code == 200
     assert resp.json() == {"TITLE": "Book Store"}
 
 
 def test_fetch_group_multiple_values():
     client = get_anonymous_client()
-    resp = client.get("/content-settings/fetch/home-detail/")
+    resp = client.get("/books/fetch/home-detail/")
     assert resp.status_code == 200
     assert resp.json() == {
         "DESCRIPTION": "Book Store is the best book store in the world",
@@ -67,12 +67,22 @@ def test_fetch_group_multiple_values():
     }
 
     client = get_staff_client()
-    resp = client.get("/content-settings/fetch/home-detail/")
+    resp = client.get("/books/fetch/home-detail/")
     assert resp.status_code == 200
     assert resp.json() == {
         "DESCRIPTION": "Book Store is the best book store in the world",
         "OPEN_DATE": "2023-01-01",
         "TITLE": "Book Store",
+    }
+
+
+def test_fetch_group_suffix():
+    client = get_anonymous_client()
+    resp = client.get("/books/fetch/main/")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "TITLE": "Book Store",
+        "BOOKS__available_names": ["Kateryna", "The Poplar", "The Night of Taras"],
     }
 
 
@@ -86,9 +96,6 @@ def test_fetch_group_multiple_values():
         ["staff", "open-date", 200],
         ["staff", "OPEN-DATE", 200],
         ["staff", "OPEN_DATE", 200],
-        ["anonymous", "home-detail", 200],
-        ["authenticated", "home-detail", 200],
-        ["staff", "home-detail", 200],
     ],
 )
 def test_fetch_permissions(client, name, status_code):
@@ -124,3 +131,11 @@ def test_get_simple_text_updated_twice():
         resp = client.get("/content-settings/fetch/title/")
         assert resp.status_code == 200
         assert resp.json() == {"TITLE": "SUPER New Book Store"}
+
+
+def test_fetch_suffix():
+    client = get_anonymous_client()
+    resp = client.get("/content-settings/fetch/books/suffix/available-names/")
+    assert resp.json() == {
+        "BOOKS__available_names": ["Kateryna", "The Poplar", "The Night of Taras"]
+    }

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,24 @@
+import pytest
+
+from content_settings.conf import split_attr
+
+
+@pytest.mark.parametrize(
+    "line,val",
+    [
+        ("TITLE", (None, "TITLE", None)),
+        ("type__TITLE", ("type", "TITLE", None)),
+        ("type__TITLE", ("type", "TITLE", None)),
+        ("type__TITLE_SUBTITLE", ("type", "TITLE_SUBTITLE", None)),
+        ("type__TITLE__SUBTITLE", ("type", "TITLE__SUBTITLE", None)),
+        ("TITLE__SUBTITLE", (None, "TITLE__SUBTITLE", None)),
+        ("TITLE__SUBTITLE__name", (None, "TITLE__SUBTITLE", "name")),
+        ("TITLE__SUBTITLE__name__upper", (None, "TITLE__SUBTITLE", "name__upper")),
+        (
+            "type__TITLE__SUBTITLE__name__upper",
+            ("type", "TITLE__SUBTITLE", "name__upper"),
+        ),
+    ],
+)
+def test_split_attr(line, val):
+    assert split_attr(line) == val


### PR DESCRIPTION
https://github.com/occipital/django-content-settings/issues/7

* deprication of `fetch_groups` attribute
* `lazy_give` new function for giving a lazy object. `LazyObject` moved to own module
* `split_attr` new function for splitting attribute of prefix, name and suffix
* uppercase for variable name is mandatory
* `call` suffix for `GiveCallMixin`
* DictSuffixesMixin - use dict for suffixes, where values are lambdas
* `suffix` is URLs for getting value from suffix
* `FetchSettingsView` as a replacement for `fetch_groups`