### PR TITLE
Fix middleware preview_on_site typo

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -186,7 +186,7 @@
 ![DictSuffixesPreviewMixin](img/preview_on_site.png)
 
 * admin can now preview settings on site before applying
-* new middleware `middlewares.preivew_on_site`
+* new middleware `middlewares.preview_on_site`
 
 ### 0.10.2
 


### PR DESCRIPTION
## Summary
- fix typo in preview middleware name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68429ca764d08328ab988e48536c2c01