### PR TITLE
Fix typo in admin comment

### DIFF
--- a/content_settings/admin.py
+++ b/content_settings/admin.py
@@ -114,7 +114,7 @@ class SettingsChangeList(ChangeList):
                 combine &= Q(tags__iregex=rf"(^|\n){tag}($|\n)")
 
             q = q.filter(combine)
-        # This is terrable
+        # This is terrible
         # But I don't know how to do it better
         # I need to filter out the names user don't have permissions to see
 


### PR DESCRIPTION
## Summary
- fix spelling error "terrable" -> "terrible" in admin.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68429c87b15c8328b64a6e2647745724