### PR TITLE
Fix checksum user key setting

### DIFF
--- a/content_settings/settings.py
+++ b/content_settings/settings.py
@@ -29,7 +29,9 @@ CHECKSUM_KEY_PREFIX = (
 )
 
 CHECKSUM_USER_KEY_PREFIX = (
-    get_setting("CHECKSUM_KEY_PREFIX", "CS_USER_CHECKSUM_") + __version__ + "__"
+    get_setting("CHECKSUM_USER_KEY_PREFIX", "CS_USER_CHECKSUM_")
+    + __version__
+    + "__"
 )
 
 USER_TAGS = get_setting(


### PR DESCRIPTION
## Summary
- fix the user checksum setting name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68429ca35fd48328b6d11dcd7a7dac2b