### PR TITLE
Switch threadlocals to asgiref local

### DIFF
--- a/content_settings/cache_triggers.py
+++ b/content_settings/cache_triggers.py
@@ -5,7 +5,10 @@
 from typing import Any, Dict, Set, Optional, List
 import hashlib
 from functools import cached_property
-from threading import local
+try:
+    from asgiref.local import Local
+except ImportError:  # pragma: no cover - fallback for very old setups
+    from threading import local as Local
 
 from django.core.cache import caches
 
@@ -15,7 +18,7 @@ from .settings import (
 )
 
 
-class ThreadLocalData(local):
+class ThreadLocalData(Local):
     ALL_VALUES_CHECKSUM: str = ""
 
 

--- a/content_settings/caching.py
+++ b/content_settings/caching.py
@@ -9,7 +9,10 @@ the caching backend is working with local thread storage to store the checksum r
 * `POPULATED: bool` - the flag that indicates that all values were populated from the database
 """
 
-import threading
+try:
+    from asgiref.local import Local
+except ImportError:  # pragma: no cover - fallback for old setups
+    from threading import local as Local
 from typing import Any, Dict, Set, Optional, List
 
 from django.conf import settings
@@ -30,7 +33,7 @@ TRIGGER = import_object(CACHE_TRIGGER["backend"])(
 )
 
 
-class ThreadLocalData(threading.local):
+class ThreadLocalData(Local):
     POPULATED: bool = False
     ALL_RAW_VALUES: Optional[Dict[str, str]] = None
     ALL_VALUES: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- use `asgiref.local.Local` for caching and cache triggers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68429db4af5c8328a890680f9ef5a437