### PR TITLE
Use asgiref local storage

### DIFF
--- a/content_settings/cache_triggers.py
+++ b/content_settings/cache_triggers.py
@@ -5,7 +5,7 @@
 from typing import Any, Dict, Set, Optional, List
 import hashlib
 from functools import cached_property
-from threading import local
+from asgiref.local import Local
 
 from django.core.cache import caches
 
@@ -15,11 +15,13 @@ from .settings import (
 )
 
 
-class ThreadLocalData(local):
-    ALL_VALUES_CHECKSUM: str = ""
+class ThreadLocalData(Local):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.ALL_VALUES_CHECKSUM: str = ""
 
 
-DATA = ThreadLocalData()
+DATA = ThreadLocalData(thread_critical=True)
 
 
 class BaseCacheTrigger:
@@ -135,7 +137,7 @@ class VersionChecksum(BaseCacheTrigger):
 
     def set_local_checksum(self, value: Optional[str] = None) -> None:
         """
-        calculate and set checksum in the local thread
+        calculate and set checksum in the context-local storage
         """
         if value is None:
             value = self.calc_checksum()

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,16 +1,16 @@
 # Caching
 
-There are two storage mechanisms for raw data: the database (DB) and thread-local storage. The cache is used to signal when the local cache needs to be updated.
+There are two storage mechanisms for raw data: the database (DB) and context-local storage. The cache is used to signal when the local cache needs to be updated.
 
 During the first run, a checksum is calculated for all registered variables. This checksum acts as a cache key that signals when a value has been updated and needs to be refreshed from the DB.
 
-Values from the DB are retrieved only when at least one setting in the thread is requested. In this case, data is fetched from the DB only when required.
+Values from the DB are retrieved only when at least one setting in the context is requested. In this case, data is fetched from the DB only when required.
 
-Once at least one setting is requested, all raw values are fetched and saved in the thread-local storage. This ensures that all settings remain consistent.
+Once at least one setting is requested, all raw values are fetched and saved in the context-local storage. This ensures that all settings remain consistent.
 
 Raw data for a setting is converted to a Python object only when the setting is requested. This avoids unnecessary processing of all raw data. Since raw data can be converted to a Python object at any time, this approach is efficient.
 
-For every request, the system checks the cache to verify if the checksum value has changed. If it has, the thread-local data is marked as unpopulated.
+For every request, the system checks the cache to verify if the checksum value has changed. If it has, the context-local data is marked as unpopulated.
 
 When the system repopulates (i.e., a setting is requested again after being marked unpopulated), it updates all raw values. However, Python objects are invalidated only if the corresponding raw value has changed.
 
@@ -60,11 +60,11 @@ The checksum is validated in the following scenarios:
 
 *Experimental Feature*
 
-The system allows all Python objects to be precached for each thread at the time the thread starts (e.g., when the DB connection is initialized).
+The system allows all Python objects to be precached for each thread or async context at the time it starts (e.g., when the DB connection is initialized).
 
 To activate this feature, set: `CONTENT_SETTINGS_PRECACHED_PY_VALUES = True`
 
-Note: This feature might cause issues if a new thread is started for every request.
+Note: This feature might cause issues if a new thread or async context is started for every request.
 
 See also [`content_settings.caching`](source.md#caching).
 

--- a/docs/source.md
+++ b/docs/source.md
@@ -17,7 +17,6 @@
 - [utils](#utils)
 - [views](#views)
 - [widgets](#widgets)
-- [templatetags.content_settings_extras](#templatetagscontent_settings_extras)
 - [types.array](#typesarray)
 - [types.basic](#typesbasic)
 - [types.datetime](#typesdatetime)
@@ -31,6 +30,7 @@
 - [defaults.context](#defaultscontext)
 - [defaults.filters](#defaultsfilters)
 - [defaults.modifiers](#defaultsmodifiers)
+- [templatetags.content_settings_extras](#templatetagscontent_settings_extras)
 
 
 
@@ -40,7 +40,7 @@
 
 # Cache Trigger is a backend to sending a signal of when py-object(s) should be updated
 
-### class VersionChecksum(BaseCacheTrigger)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L58)</sup>
+### class VersionChecksum(BaseCacheTrigger)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L60)</sup>
 
 Arguments:
     * cache_backend (str, default="default"): cache backend name
@@ -55,31 +55,31 @@ The algorithm:
     * if the DB values are changed it saves the new checksum under the same cache key (so only instances with the same configuration will see the change)
     * if the checksum is changed comparing to the checksum in the local storage
 
-#### def hash_value(self, value: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L87)</sup>
+#### def hash_value(self, value: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L89)</sup>
 
 generate md5 hash for a string
 
-#### def dict_checksum(self, values: Dict[str, Any])<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L93)</sup>
+#### def dict_checksum(self, values: Dict[str, Any])<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L95)</sup>
 
 generate md5 hash for a dict with keys and values as strings
 
-#### def cache_key(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L104)</sup>
+#### def cache_key(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L106)</sup>
 
 returns cache key for checksum values (one should not be changed over time)
 
-#### def user_cache_key_prefix(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L123)</sup>
+#### def user_cache_key_prefix(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L125)</sup>
 
 returns cache key for user defined types (one should not be changed over time) if user defined types are not used, returns None
 
-#### def set_local_checksum(self, value: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L136)</sup>
+#### def set_local_checksum(self, value: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L138)</sup>
 
-calculate and set checksum in the local thread
+calculate and set checksum in the context-local storage
 
-#### def push_checksum(self, value: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L160)</sup>
+#### def push_checksum(self, value: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L162)</sup>
 
 save to cache backend the checksum
 
-#### def get_checksum_from_cache(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L170)</sup>
+#### def get_checksum_from_cache(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/cache_triggers.py#L172)</sup>
 
 get the checksum from the cache backend
 
@@ -88,106 +88,106 @@ get the checksum from the cache backend
 
 
 
-the caching backend is working with local thread storage to store the checksum raw and py objects.
+the caching backend is working with context-local storage to store the checksum raw and py objects.
 
-`DATA` is a local thread storage with the following attributes:
+`DATA` is a context-local storage with the following attributes:
 
 * `ALL_RAW_VALUES: Dict[str, str]` - the raw values (values from the database) of the all settings
 * `ALL_VALUES: Dict[str, Any]` - the python objects of the all settings
 * `ALL_USER_DEFINES: Dict[str, BaseSetting]` - key is the setting name, value is the user defined type (with tags and help text)
 * `POPULATED: bool` - the flag that indicates that all values were populated from the database
 
-### def set_new_type(name: str, user_defined_type: str, tags_set: Optional[Set[str]] = None, help: str = '')<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L49)</sup>
+### def set_new_type(name: str, user_defined_type: str, tags_set: Optional[Set[str]] = None, help: str = '')<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L51)</sup>
 
-create a new user defined type and saves it to the local thread. The previous type is returned.
+create a new user defined type and saves it to the context-local storage. The previous type is returned.
 
-### def replace_user_type(name: str, cs_type: BaseSetting)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L78)</sup>
+### def replace_user_type(name: str, cs_type: BaseSetting)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L80)</sup>
 
 replace the user defined type with the new one. The previous type is returned.
 
-### def set_new_value(name: str, new_value: str, version: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L90)</sup>
+### def set_new_value(name: str, new_value: str, version: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L92)</sup>
 
-takes name, raw value and saves it to the local thread if the value was changed. The previous value is returned.
+takes name, raw value and saves it to the context-local storage if the value was changed. The previous value is returned.
 
-raw value converts to the python object and saves to the local thread.
+raw value converts to the python object and saves to the context-local storage.
 
 if version is not None - it will be verified against the version of the type
 
-### def delete_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L113)</sup>
+### def delete_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L115)</sup>
 
-delete the value from the local thread
+delete the value from the context-local storage
 
-### def set_new_db_value(name: str, value: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L122)</sup>
+### def set_new_db_value(name: str, value: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L124)</sup>
 
 set the new value for the setting in DB
 
-### def delete_user_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L162)</sup>
+### def delete_user_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L164)</sup>
 
-delete user defined setting from the local thread and returns its raw value
+delete user defined setting from the context-local storage and returns its raw value
 
-### def get_type_by_name(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L178)</sup>
+### def get_type_by_name(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L180)</sup>
 
 get the type of the setting (inluding user defined types) by its name
 
-### def get_userdefined_type_by_name(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L193)</sup>
+### def get_userdefined_type_by_name(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L195)</sup>
 
 get the user defined type by its name
 
-### def get_value(name: str, suffix: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L203)</sup>
+### def get_value(name: str, suffix: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L205)</sup>
 
 get the value of the setting by its name and optional suffix
 
-### def get_raw_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L215)</sup>
+### def get_raw_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L217)</sup>
 
 get the raw value of the setting by its name
 
-### def get_constant_py_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L230)</sup>
+### def get_constant_py_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L232)</sup>
 
 get the python object of the constant setting by its name
 
-### def get_py_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L247)</sup>
+### def get_py_value(name: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L249)</sup>
 
 get the python object of the setting by its name
 
-### def is_populated()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L271)</sup>
+### def is_populated()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L273)</sup>
 
-check if the local thread is populated with the values from the database and it is actual
+check if the context-local storage is populated with the values from the database and it is actual
 
-### def get_db_objects()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L287)</sup>
+### def get_db_objects()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L289)</sup>
 
 get the database objects for the settings
 
-### def get_all_names()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L296)</sup>
+### def get_all_names()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L298)</sup>
 
-get the names of the settings (including user defined types) from the local thread
+get the names of the settings (including user defined types) from the context-local storage
 
-### def populate()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L306)</sup>
+### def populate()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L308)</sup>
 
-reset the local thread with the values from the database
+reset the context-local storage with the values from the database
 
-### def validate_default_values()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L327)</sup>
+### def validate_default_values()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L329)</sup>
 
 validate default values for all of the registered settings.
 
-### def reset_user_values(db: Optional[Dict[str, Any]] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L351)</sup>
+### def reset_user_values(db: Optional[Dict[str, Any]] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L353)</sup>
 
-reset the local thread with the values from the database for user defined types
+reset the context-local storage with the values from the database for user defined types
 
-if trigger_checksum is not the same as the checksum in the local thread, the checksum in the cache backend will be updated
+if trigger_checksum is not the same as the checksum in the context-local storage, the checksum in the cache backend will be updated
 
-### def reset_values(db: Optional[Dict[str, Any]] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L387)</sup>
+### def reset_values(db: Optional[Dict[str, Any]] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L389)</sup>
 
-reset the local thread with the values from the database for code settings
+reset the context-local storage with the values from the database for code settings
 
-if trigger_checksum is not the same as the checksum in the local thread, the checksum in the cache backend will be updated
+if trigger_checksum is not the same as the checksum in the context-local storage, the checksum in the cache backend will be updated
 
-### def check_update()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L425)</sup>
+### def check_update()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L427)</sup>
 
-check if checksum in the cache backend is the same as the checksum in the local thread
+check if checksum in the cache backend is the same as the checksum in the context-local storage
 
 if not, the values from the database will be loaded
 
-### def recalc_checksums()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L437)</sup>
+### def recalc_checksums()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/caching.py#L439)</sup>
 
 recalculate the checksums in the cache backend
 
@@ -240,7 +240,7 @@ withtag__ prefix that returns all settings as a dict (setting name: setting valu
 
 exception that is raised when the attribute name is not valid
 
-### def split_attr(value: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L139)</sup>
+### def split_attr(value: str)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L140)</sup>
 
 splits the name of the attr on 3 parts: prefix, name, suffix
 
@@ -248,13 +248,13 @@ splits the name of the attr on 3 parts: prefix, name, suffix
 * name should be uppercase
 * suffix can be any string, but not uppercase
 
-### def validate_all_with_context(context: Dict[str, Any])<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L176)</sup>
+### def validate_all_with_context(context: Dict[str, Any])<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L179)</sup>
 
 validate all settings with the given context to make sure all of them are valid.
 
 Do not perform if `CONTENT_SETTINGS_CHAIN_VALIDATE = False`
 
-### def get_str_tags(cs_name: str, cs_type: BaseSetting, value: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L196)</sup>
+### def get_str_tags(cs_name: str, cs_type: BaseSetting, value: Optional[str] = None)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L199)</sup>
 
     get tags as a text (joined by `
 `) for specific setting type. name and value are used to generate content tags.
@@ -262,7 +262,7 @@ Do not perform if `CONTENT_SETTINGS_CHAIN_VALIDATE = False`
     from saving in DB.
     
 
-### def set_initial_values_for_db(apply: bool = False)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L212)</sup>
+### def set_initial_values_for_db(apply: bool = False)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L215)</sup>
 
 sync settings with DB.
     * creates settings that are not in DB
@@ -271,25 +271,25 @@ sync settings with DB.
 
 attribute `apply` is used to apply changes in DB immediately. Can be used in tests.
 
-### class _Settings()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L371)</sup>
+### class _Settings()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L374)</sup>
 
 the main object that uses for getting settings for cache.
 
-#### def __dir__(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L394)</sup>
+#### def __dir__(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L397)</sup>
 
 dir() returns all settings names
 
-#### def form_checksum(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L410)</sup>
+#### def form_checksum(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L413)</sup>
 
 the current checksum of the settings.
 
 used for validation of settings weren't changed over time.
 
-#### def admin_head(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L419)</sup>
+#### def admin_head(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L422)</sup>
 
 the admin head.
 
-#### def admin_raw_js(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L426)</sup>
+#### def admin_raw_js(self)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/conf.py#L429)</sup>
 
 the admin raw js.
 
@@ -793,17 +793,6 @@ Long URL Input
 ### class LongEmailInput(LongInputMix, EmailInput)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/widgets.py#L45)</sup>
 
 Long Email Input
-
-
-## templatetags.content_settings_extras
-
-
-
-
-
-### def content_settings_call(name)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/templatetags/content_settings_extras.py#L12)</sup>
-
-template tag that call callable settings in the template
 
 
 ## types.array
@@ -1715,6 +1704,17 @@ add widget class or classes splited by space.
 ### def update_widget_attrs()<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/defaults/modifiers.py#L332)</sup>
 
 update widget attrs
+
+
+## templatetags.content_settings_extras
+
+
+
+
+
+### def content_settings_call(name)<sup>[source](https://github.com/occipital/django-content-settings/blob/master/content_settings/templatetags/content_settings_extras.py#L12)</sup>
+
+template tag that call callable settings in the template
 
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner-direct-single.svg)](https://stand-with-ukraine.pp.ua)
 


### PR DESCRIPTION
## Summary
- switch caching and cache triggers to use `asgiref.local.Local`
- regenerate documentation
- clarify docs about context-local storage

## Testing
- `make mdsource`
- `make test-all`

------
https://chatgpt.com/codex/tasks/task_e_6842acde00e483288e9a4d4694d5ae2d